### PR TITLE
Supoort sending contents data for Dynamic Template

### DIFF
--- a/lib/src/models/email.dart
+++ b/lib/src/models/email.dart
@@ -48,7 +48,7 @@ class Email {
         'from': from.toJson(),
         'reply_to': replyTo?.toJson(),
         'subject': subject,
-        'content': content.map((e) => e.toJson()).toList(),
+        'content': content?.map((e) => e.toJson())?.toList(),
         'attachments': attachments?.map((e) => e.toJson())?.toList(),
         'template_id': templateId,
         'headers': headers,

--- a/lib/src/models/email.dart
+++ b/lib/src/models/email.dart
@@ -10,8 +10,8 @@ class Email {
   const Email(
     this.personalizations,
     this.from,
-    this.content,
     this.subject, {
+    this.content,
     this.replyTo,
     this.attachments,
     this.templateId,

--- a/lib/src/models/personalization.dart
+++ b/lib/src/models/personalization.dart
@@ -10,6 +10,7 @@ class Personalization {
     this.substitutions,
     this.customArgs,
     this.sendAt,
+    this.dynamicTemplateData,
   });
 
   final List<Address> to;
@@ -20,6 +21,7 @@ class Personalization {
   final Map<String, String> substitutions;
   final Map<String, String> customArgs;
   final DateTime sendAt;
+  final Map<String, dynamic> dynamicTemplateData;
 
   Map<String, dynamic> toJson() => {
         'to': to.map((e) => e.toJson()).toList(),
@@ -30,5 +32,6 @@ class Personalization {
         'substitutions': substitutions,
         'custom_args': customArgs,
         'send_at': sendAt?.toUtc()?.millisecondsSinceEpoch,
+        'dynamic_template_data': dynamicTemplateData,
       };
 }


### PR DESCRIPTION
Thank you for publishing awsome package!

I tried to use Dynamic Templates feature via this package, but the package didn't have an interface to set the template data. Therefore, I added field of `dynamic_template_data` to Personalization.

## Related official document
https://sendgrid.com/docs/ui/sending-email/how-to-send-an-email-with-dynamic-transactional-templates/#send-a-transactional-email

## Official SDK's implementation in Java 
https://github.com/sendgrid/sendgrid-java/blob/2d82397f32cd14efb7a5fc28fafa019613968f3a/src/main/java/com/sendgrid/helpers/mail/objects/Personalization.java#L36